### PR TITLE
Rudimentary approach to alternative install paths.

### DIFF
--- a/LeagueLocaleLauncher/Config.cs
+++ b/LeagueLocaleLauncher/Config.cs
@@ -14,8 +14,12 @@ namespace LeagueLocaleLauncher
         public string ToolCulture = CultureInfo.CurrentCulture.ToString();
         public Region Region = Region.NA;
         public Language Language = Language.ENGLISH_UNITED_STATES;
-        public string LeagueClientSettingsPath = @"C:\Riot Games\League of Legends\Config\LeagueClientSettings.yaml";
-        public string LeagueClientPath = @"C:\Riot Games\League of Legends\LeagueClient.exe";
+        public string LeagueBasePath = @"C:\Riot Games\League of Legends\";
+
+        public string LeagueClientExecutable { get; } = "LeagueClient.exe";
+
+        public string LeagueClientSettingsPath => Path.Combine(LeagueBasePath, @"Config\LeagueClientSettings.yaml");
+        public string LeagueClientPath => Path.Combine(LeagueBasePath, LeagueClientExecutable);
 
         public HashSet<string> LeagueProcessNames = new HashSet<string> { };
 


### PR DESCRIPTION
This should solve an issue someone raised in the discord, where the app doesn't account for the configurable install location from riot's League of Legends installer.

Currently this is a very basic an quick fix. But I didn't want to change much of the logic without being given the go ahead on making it cleaner.